### PR TITLE
[Feat] refresh 도중 endRefresh가 먼저 끝나도록 시간 지연 설정

### DIFF
--- a/UnsplashImage/OurTopic/View/TopicPhotoView.swift
+++ b/UnsplashImage/OurTopic/View/TopicPhotoView.swift
@@ -12,6 +12,7 @@ import SnapKit
 class TopicPhotoView: BaseView {
     
     let scrollView = UIScrollView()
+    let refreshControl = UIRefreshControl()
     let contentView = UIView()
     let firstCollectionView: UICollectionView
     let firstLabel = UILabel()
@@ -53,6 +54,7 @@ class TopicPhotoView: BaseView {
     
     override func configHierarchy() {
         self.addSubview(scrollView)
+        scrollView.addSubview(refreshControl)
         scrollView.addSubview(contentView)
         [firstLabel, firstCollectionView, secondLabel, secondCollectionView, thirdLabel, thirdCollectionView].forEach {
             contentView.addSubview($0)

--- a/UnsplashImage/OurTopic/View/TopicPhotoViewController.swift
+++ b/UnsplashImage/OurTopic/View/TopicPhotoViewController.swift
@@ -36,19 +36,13 @@ class TopicPhotoViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .white
+        mainView.scrollView.alwaysBounceVertical = true
+        mainView.scrollView.bounces = true
+        mainView.scrollView.delegate = self
         setCollectionView()
         setNavigation()
         
-        threeTopics = Array(Topic.allCases.shuffled().prefix(3))
-        print(threeTopics)
-        
-        for index in 0...2 {
-            getImageData(topicQuery: threeTopics[index].queryParameter)
-        }
-        
-        mainView.firstLabel.text = threeTopics[0].name
-        mainView.secondLabel.text = threeTopics[1].name
-        mainView.thirdLabel.text = threeTopics[2].name
+        setRandomTopic()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -92,6 +86,18 @@ class TopicPhotoViewController: UIViewController {
         navigationController?.navigationBar.tintColor = .label
         navigationItem.title = "돌려돌려 랜덤 TOPIC"
         navigationItem.backButtonTitle = ""
+    }
+    
+    func setRandomTopic() {
+        threeTopics = Array(Topic.allCases.shuffled().prefix(3))
+        
+        for index in 0...2 {
+            getImageData(topicQuery: threeTopics[index].queryParameter)
+        }
+        
+        mainView.firstLabel.text = threeTopics[0].name
+        mainView.secondLabel.text = threeTopics[1].name
+        mainView.thirdLabel.text = threeTopics[2].name
     }
 
 }
@@ -202,6 +208,20 @@ extension TopicPhotoViewController: UICollectionViewDelegate, UICollectionViewDa
         vc.height = row.height
     }
     
+}
+
+extension TopicPhotoViewController: UIScrollViewDelegate {
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if scrollView.contentOffset.y <= -70 {
+            mainView.refreshControl.beginRefreshing()
+            print("start refresh")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                self.setRandomTopic()
+            }
+            mainView.refreshControl.endRefreshing()
+        }
+    }
 }
 
 extension TopicPhotoViewController {


### PR DESCRIPTION
## 한 일
1. VC에 얹을 UIView에 UIRefreshController 추가
2. VC에서 delegate 활성화 및 scrollViewDidEndDragging 메서드 활용해 일정 offset을 잡아 당길 시 refresh 되도록 설정
- endRefreshing이 끝나면 데이터가 변환되길 바래서 약간의 지연시간을 추가함

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-20 at 19 38 53](https://github.com/user-attachments/assets/1d374065-9b69-4afc-b9d5-20c836d3d51c)
