### PR TITLE
[Refactor] networkingManager에 url 관련 열거형 생성하여 구조 수정

### DIFF
--- a/UnsplashImage/BaseCell/BaseCollectionViewCell.swift
+++ b/UnsplashImage/BaseCell/BaseCollectionViewCell.swift
@@ -30,23 +30,14 @@ class BaseCollectionViewCell: UICollectionViewCell {
     
     override func layoutSubviews() {
         print(#function)
-//                    self.likeBgView.layer.cornerRadius = self.likeBgView.frame.height / 2
-//                    self.likeBgView.clipsToBounds = true
-//                    self.thumImage.clipsToBounds = true
-        // ❔layoutSubview는 이미 객체의 프레임이 다 잡히고 실행한다고 알고있고, 이미 메인에서 동작하고 있는데 왜 강제로 지연시키기 않으면 cornerRadius가 들지 않나요?
-//        DispatchQueue.main.async {
-//            self.likeBgView.layer.cornerRadius = self.likeBgView.frame.height / 2
-//            self.likeBgView.clipsToBounds = true
-//            self.thumImage.clipsToBounds = true
-//        }
+
+        DispatchQueue.main.async {
+            self.likeBgView.layer.cornerRadius = self.likeBgView.frame.height / 2
+            self.likeBgView.clipsToBounds = true
+            self.thumImage.clipsToBounds = true
+        }
     }
-    
-    override func draw(_ rect: CGRect) {
-        print(#function)
-        self.likeBgView.layer.cornerRadius = self.likeBgView.frame.height / 2
-        self.likeBgView.clipsToBounds = true
-        self.thumImage.clipsToBounds = true
-    }
+
 }
 
 extension BaseCollectionViewCell {

--- a/UnsplashImage/OurTopic/View/TopicDetailViewController.swift
+++ b/UnsplashImage/OurTopic/View/TopicDetailViewController.swift
@@ -37,12 +37,8 @@ class TopicDetailViewController: UIViewController {
     }
  
     func getInfoData() {
-        
-        guard let apiKey = Bundle.main.apiKey else { return }
-        
-        let url = "https://api.unsplash.com/photos/\(userId)/statistics?client_id=\(apiKey)"
-        
-        networkingManager.callRequest(url: url) { data in
+ 
+        networkingManager.callRequest(api: .statistics(userId: userId)) { data in
             
             guard let result = try? self.networkingManager.decoder.decode(Statistics.self, from: data) else { return }
             

--- a/UnsplashImage/OurTopic/View/TopicPhotoViewController.swift
+++ b/UnsplashImage/OurTopic/View/TopicPhotoViewController.swift
@@ -59,12 +59,7 @@ class TopicPhotoViewController: UIViewController {
     
     func getImageData(topicQuery: String) {
         
-        guard let apiKey = Bundle.main.apiKey else { return }
-        
-        // router pattern
-        let url = "https://api.unsplash.com/topics/\(topicQuery)/photos?page=1&client_id=\(apiKey)"
-        
-        networkingManager.callRequest(url: url) { data in
+        networkingManager.callRequest(api: .topic(topic: topicQuery)) { data in
             guard let result = try? self.networkingManager.decoder.decode([PhotoTopic].self, from: data) else { return }
             
             switch topicQuery {

--- a/UnsplashImage/SearchPhoto/View/SearchPhotoDetailViewController.swift
+++ b/UnsplashImage/SearchPhoto/View/SearchPhotoDetailViewController.swift
@@ -42,12 +42,8 @@ class SearchPhotoDetailViewController: UIViewController {
     }
     
     func getInfoData() {
-        
-        guard let apiKey = Bundle.main.apiKey else { return }
-        
-        let url = "https://api.unsplash.com/photos/\(userId)/statistics?client_id=\(apiKey)"
-        
-        networkManager.callRequest(url: url) { data in
+
+        networkManager.callRequest(api: .statistics(userId: userId)) { data in
             
             guard let result = try? self.networkManager.decoder.decode(Statistics.self, from: data) else { return print("decoding error") }
             

--- a/UnsplashImage/SearchPhoto/View/SearchPhotoViewController.swift
+++ b/UnsplashImage/SearchPhoto/View/SearchPhotoViewController.swift
@@ -47,21 +47,26 @@ class SearchPhotoViewController: UIViewController, UISearchBarDelegate, UISearch
 
     func getPhotoData() {
         
-        guard let apiKey = Bundle.main.apiKey else { return }
-        print(apiKey)
         
-        let url = "https://api.unsplash.com/search/photos?query=\(keyword)&page=\(page)&per_page=20&order_by=\(sort)&color=\(colorFilter)&client_id=\(apiKey)"
    
-        networkManager.callRequest(url: url) { data in
+        networkManager.callRequest(api: .search(query: keyword, page: page, sort: sort, color: colorFilter)) { data in
             
             guard let result = try? self.networkManager.decoder.decode(PhotoSearch.self, from: data) else { return print("decoding failed") }
 
             self.total = result.total
             
-            if self.total == 0 {
+//            if self.total == 0 {
+//                self.mainView.imageCollectionView.isHidden = true
+//                self.mainView.defaultLabel.text = "검색결과가 없어요(영어만 인식해요!)"
+//            } else {
+//                self.mainView.imageCollectionView.isHidden = false
+//            }
+            
+            switch self.total {
+            case 0:
                 self.mainView.imageCollectionView.isHidden = true
                 self.mainView.defaultLabel.text = "검색결과가 없어요(영어만 인식해요!)"
-            } else {
+            default:
                 self.mainView.imageCollectionView.isHidden = false
             }
             


### PR DESCRIPTION
## 한 일
1. 기존에 NetworkingManager의 메서드를 받던 VC에서 직접 url을 하드코딩으로 받아 사용했던 부분을 manager의 enum으로 만들어 호출해 사용
- url 내부 파라미터로 받던 부분은 열거형의 연관값으로 교체