### PR TITLE
[Refactor] DispatchGroup 사용하여 TopicView 코드 개선

### DIFF
--- a/UnsplashImage.xcodeproj/project.pbxproj
+++ b/UnsplashImage.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -209,6 +210,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/UnsplashImage/BaseCell/BaseCollectionViewCell.swift
+++ b/UnsplashImage/BaseCell/BaseCollectionViewCell.swift
@@ -29,8 +29,7 @@ class BaseCollectionViewCell: UICollectionViewCell {
     }
     
     override func layoutSubviews() {
-        print(#function)
-
+  
         DispatchQueue.main.async {
             self.likeBgView.layer.cornerRadius = self.likeBgView.frame.height / 2
             self.likeBgView.clipsToBounds = true


### PR DESCRIPTION
## 한 일
1. Topic collectionView 3개의 네트워크 통신 받는 부분 DispatchGroup 활용하도록 수정
- 기존에 배열의 변화를 감지하는 didSet을 사용하고 있었는데, group.leave()를 사용하기 위해 제거 후 일괄 reload 하는 것으로 수정

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-21 at 19 58 34](https://github.com/user-attachments/assets/ba9d479c-6586-40fd-9410-721986fcd08a)