### PR TITLE
[Feat] #36 네트워크 통신 상태코드에 따른 예외처리 진행

### DIFF
--- a/UnsplashImage.xcodeproj/xcuserdata/leewonsun.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/UnsplashImage.xcodeproj/xcuserdata/leewonsun.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>UnsplashImage.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/UnsplashImage/Enum/APIStatus.swift
+++ b/UnsplashImage/Enum/APIStatus.swift
@@ -1,0 +1,31 @@
+//
+//  APIStatus.swift
+//  UnsplashImage
+//
+//  Created by Lee Wonsun on 1/23/25.
+//
+
+import Foundation
+
+enum APIStatus {
+    case ok(message: String)
+    case badRequest(message: String)
+    case unauthorized(message: String)
+    case forbidden(message: String)
+    case notFound(message: String)
+    case networkError(message: String)
+    
+    init?(statusCode: Int) {
+        switch statusCode {
+        case 200: self = .ok(message: "OK")
+        case 400: self = .badRequest(message: "Bad Request")
+        case 401: self = .unauthorized(message: "Unauthorized")
+        case 403: self = .forbidden(message: "Forbidden")
+        case 404: self = .notFound(message: "Not Found")
+        case 500, 503: self = .networkError(message: "Network Error")
+        default:
+            print("statudCode error")
+            return nil
+        }
+    }
+}

--- a/UnsplashImage/Enum/APIStatus.swift
+++ b/UnsplashImage/Enum/APIStatus.swift
@@ -17,7 +17,7 @@ enum APIStatus {
     
     init?(statusCode: Int) {
         switch statusCode {
-        case 200: self = .ok(message: "OK")
+        case 200: self = .ok(message: "Connec Success")
         case 400: self = .badRequest(message: "Bad Request")
         case 401: self = .unauthorized(message: "Unauthorized")
         case 403: self = .forbidden(message: "Forbidden")
@@ -28,4 +28,24 @@ enum APIStatus {
             return nil
         }
     }
+    
+    var alertMessage: String {
+        switch self {
+        case .ok(let message): message
+        case .badRequest(let message): message
+        case .unauthorized(let message): message
+        case .forbidden(let message): message
+        case .notFound(let message): message
+        case .networkError(let message): message
+        }
+    }
 }
+
+/*
+ 200 - OK    Everything worked as expected
+ 400 - Bad Request    The request was unacceptable, often due to missing a required parameter
+ 401 - Unauthorized    Invalid Access Token
+ 403 - Forbidden    Missing permissions to perform request
+ 404 - Not Found    The requested resource doesn’t exist
+ 500, 503    Something went wrong on our end
+ */

--- a/UnsplashImage/Extension/UIViewController+Extension.swift
+++ b/UnsplashImage/Extension/UIViewController+Extension.swift
@@ -9,8 +9,8 @@ import UIKit
 
 extension UIViewController {
     
-    func alertMessage(message: String) {
-        let message = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+    func alertMessage(code: Int, message: String) {
+        let message = UIAlertController(title: "StatusCode: \(code)", message: message, preferredStyle: .alert)
         let okay = UIAlertAction(title: "확인", style: .cancel)
         
         message.addAction(okay)
@@ -18,13 +18,3 @@ extension UIViewController {
     }
 
 }
-
-
-/*
- 200 - OK    Everything worked as expected
- 400 - Bad Request    The request was unacceptable, often due to missing a required parameter
- 401 - Unauthorized    Invalid Access Token
- 403 - Forbidden    Missing permissions to perform request
- 404 - Not Found    The requested resource doesn’t exist
- 500, 503    Something went wrong on our end
- */

--- a/UnsplashImage/Extension/UIViewController+Extension.swift
+++ b/UnsplashImage/Extension/UIViewController+Extension.swift
@@ -16,4 +16,15 @@ extension UIViewController {
         message.addAction(okay)
         present(message, animated: true)
     }
+
 }
+
+
+/*
+ 200 - OK    Everything worked as expected
+ 400 - Bad Request    The request was unacceptable, often due to missing a required parameter
+ 401 - Unauthorized    Invalid Access Token
+ 403 - Forbidden    Missing permissions to perform request
+ 404 - Not Found    The requested resource doesn’t exist
+ 500, 503    Something went wrong on our end
+ */

--- a/UnsplashImage/Manager/NetworkingManager.swift
+++ b/UnsplashImage/Manager/NetworkingManager.swift
@@ -44,7 +44,7 @@ final class NetworkingManager {
             })
     }
     
-    func callRequestByGeneric<T: Decodable>(type: T.Type, api: UnsplashAPI, completeHandler: @escaping (T) -> (), failHandler: @escaping () -> ()) {
+    func callRequestByGeneric<T: Decodable>(type: T.Type, api: UnsplashAPI, completeHandler: @escaping (T) -> (), failHandler: @escaping () -> (), statusHandler: @escaping (Int) -> ()) {
         AF.request(api.endPoint,
                    method: api.method,
                    parameters: api.queryParameter,
@@ -61,6 +61,8 @@ final class NetworkingManager {
                    headers: api.header
         ).responseDecodable(of: T.self) { response in
 //            debugPrint(response)
+            guard let statusCode = response.response?.statusCode else { return }
+            statusHandler(statusCode)
             
             switch response.result {
             case let .success(value):
@@ -73,7 +75,6 @@ final class NetworkingManager {
     }
 }
 
-// 라우터 패턴 잊지말고 시간날 때 찾아보기
 extension NetworkingManager {
     
     enum UnsplashAPI {

--- a/UnsplashImage/Manager/NetworkingManager.swift
+++ b/UnsplashImage/Manager/NetworkingManager.swift
@@ -62,6 +62,7 @@ final class NetworkingManager {
         ).responseDecodable(of: T.self) { response in
 //            debugPrint(response)
             guard let statusCode = response.response?.statusCode else { return }
+            // ❔ 옵셔널로 초기화되는 enum은 어떻게 옵셔널 바인딩 써야하는지
             statusHandler(statusCode)
             
             switch response.result {

--- a/UnsplashImage/OurTopic/View/TopicDetailViewController.swift
+++ b/UnsplashImage/OurTopic/View/TopicDetailViewController.swift
@@ -53,7 +53,7 @@ final class TopicDetailViewController: UIViewController {
             self.mainView.viewCountDatailLabel.text = String(result.views.total.formatted())
             self.mainView.downloadDetailLabel.text = String(result.downloads.total.formatted())
             self.mainView.sizeDetailLabel.text = String(self.photoTopic.width.formatted()) + " x " + String(self.photoTopic.height.formatted())
-        }
+        }{
     } */
     
     func getInfoFromGeneric() {
@@ -64,6 +64,9 @@ final class TopicDetailViewController: UIViewController {
             self.mainView.sizeDetailLabel.text = String(self.photoTopic.width.formatted()) + " x " + String(self.photoTopic.height.formatted())
         } failHandler: {
             print("호출 실패했습니다")
+        } statusHandler: { statusCode in
+            guard let message = APIStatus(statusCode: statusCode)?.alertMessage else { return }
+            self.alertMessage(code: statusCode, message: message)
         }
 
     }

--- a/UnsplashImage/OurTopic/View/TopicPhotoViewController.swift
+++ b/UnsplashImage/OurTopic/View/TopicPhotoViewController.swift
@@ -99,6 +99,9 @@ final class TopicPhotoViewController: UIViewController {
             self.group.leave()
             self.count -= 1
             print("error", self.count)
+        } statusHandler: { statusCode in
+            guard let message = APIStatus(statusCode: statusCode)?.alertMessage else { return }
+            self.alertMessage(code: statusCode, message: message)
         }
 
     }

--- a/UnsplashImage/SearchPhoto/View/SearchPhotoDetailViewController.swift
+++ b/UnsplashImage/SearchPhoto/View/SearchPhotoDetailViewController.swift
@@ -66,6 +66,9 @@ final class SearchPhotoDetailViewController: UIViewController {
             
         } failHandler: {
             print("호출 오류우우우우")
+        } statusHandler: { statusCode in
+            guard let message = APIStatus(statusCode: statusCode)?.alertMessage else { return }
+            self.alertMessage(code: statusCode, message: message)
         }
 
     }

--- a/UnsplashImage/SearchPhoto/View/SearchPhotoViewController.swift
+++ b/UnsplashImage/SearchPhoto/View/SearchPhotoViewController.swift
@@ -103,8 +103,10 @@ final class SearchPhotoViewController: UIViewController, UISearchBarDelegate, UI
             }
         } failHandler: {
             print("호출 오류 발생 삐용")
+        } statusHandler: { statusCode in
+            guard let message = APIStatus(statusCode: statusCode)?.alertMessage else { return }
+            self.alertMessage(code: statusCode, message: message)
         }
-
     }
     
     @objc
@@ -181,7 +183,6 @@ extension SearchPhotoViewController: UICollectionViewDataSourcePrefetching {
             // ❔ prefetching의 특성 상 item.row가 마지막이 되기 전에 이미 감지?를 해서 원하는 딱 마지막에 alert가 안뜨는데 이 시점을 어떻게 맞출 수 있나요? (Cell for row)
             else if isEnd && (resultList.count - 1 == item.row) {
                 print("마지막페이지")
-                alertMessage(message: "마지막 페이지입니다!")
             }
         }
     }


### PR DESCRIPTION
## 한 일
1. networkingManager 내부의 통신 메서드에 Status 번호를 전달하는 handler 파라미터 생성
2. Status Code 별로 alert 창에 사용할 String message 반환하도록 enum 구현
3. 실제 뷰에서 UIViewController의 확장에 구현해둔 alertMessage 활용해 알럿창 띄워줌


![Simulator Screen Recording - iPhone 16 Pro - 2025-01-23 at 09 25 24](https://github.com/user-attachments/assets/ce4ce989-3b09-4faa-a876-86c759edf544)
