### PR TITLE
[Chore] StatusCode 처리 성공했을 때 제외하고 failHandler에 넣어서 처리하는 로직으로 수정

### DIFF
--- a/UnsplashImage/Enum/APIStatus.swift
+++ b/UnsplashImage/Enum/APIStatus.swift
@@ -7,36 +7,52 @@
 
 import Foundation
 
+// TODO: error protocol 찾아보기
 enum APIStatus {
-    case ok(message: String)
-    case badRequest(message: String)
-    case unauthorized(message: String)
-    case forbidden(message: String)
-    case notFound(message: String)
-    case networkError(message: String)
+    case ok
+    case badRequest
+    case unauthorized
+    case forbidden
+    case notFound
+    case networkError1
+    case networkError2
     
     init?(statusCode: Int) {
         switch statusCode {
-        case 200: self = .ok(message: "Connec Success")
-        case 400: self = .badRequest(message: "Bad Request")
-        case 401: self = .unauthorized(message: "Unauthorized")
-        case 403: self = .forbidden(message: "Forbidden")
-        case 404: self = .notFound(message: "Not Found")
-        case 500, 503: self = .networkError(message: "Network Error")
+        case 200: self = .ok
+        case 400: self = .badRequest
+        case 401: self = .unauthorized
+        case 403: self = .forbidden
+        case 404: self = .notFound
+        case 500: self = .networkError1
+        case 503: self = .networkError2
         default:
             print("statudCode error")
             return nil
         }
     }
     
+    var codeNumber: Int {
+        switch self {
+        case .ok: return 200
+        case .badRequest: return 400
+        case .unauthorized: return 401
+        case .forbidden: return 403
+        case .notFound: return 404
+        case .networkError1: return 500
+        case .networkError2: return 503
+        }
+    }
+    
     var alertMessage: String {
         switch self {
-        case .ok(let message): message
-        case .badRequest(let message): message
-        case .unauthorized(let message): message
-        case .forbidden(let message): message
-        case .notFound(let message): message
-        case .networkError(let message): message
+        case .ok: return "Connect Success"
+        case .badRequest: return "Bad Request"
+        case .unauthorized: return "Unauthorized"
+        case .forbidden: return "Forbidden"
+        case .notFound: return "Not Found"
+        case .networkError1: return "Network Error"
+        case .networkError2: return "Network Error"
         }
     }
 }

--- a/UnsplashImage/Manager/NetworkingManager.swift
+++ b/UnsplashImage/Manager/NetworkingManager.swift
@@ -44,7 +44,7 @@ final class NetworkingManager {
             })
     }
     
-    func callRequestByGeneric<T: Decodable>(type: T.Type, api: UnsplashAPI, completeHandler: @escaping (T) -> (), failHandler: @escaping () -> (), statusHandler: @escaping (Int) -> ()) {
+    func callRequestByGeneric<T: Decodable>(type: T.Type, api: UnsplashAPI, completeHandler: @escaping (T) -> (), failHandler: @escaping (APIStatus) -> ()) {
         AF.request(api.endPoint,
                    method: api.method,
                    parameters: api.queryParameter,
@@ -62,15 +62,14 @@ final class NetworkingManager {
         ).responseDecodable(of: T.self) { response in
 //            debugPrint(response)
             guard let statusCode = response.response?.statusCode else { return }
-            // ❔ 옵셔널로 초기화되는 enum은 어떻게 옵셔널 바인딩 써야하는지
-            statusHandler(statusCode)
             
             switch response.result {
             case let .success(value):
                 completeHandler(value)
             case let .failure(error):
                 print("매니저 에러", error)
-                failHandler()
+                guard let apiStatus = APIStatus(statusCode: statusCode) else { return }
+                failHandler(apiStatus)
             }
         }
     }

--- a/UnsplashImage/OurTopic/View/TopicDetailViewController.swift
+++ b/UnsplashImage/OurTopic/View/TopicDetailViewController.swift
@@ -62,11 +62,9 @@ final class TopicDetailViewController: UIViewController {
             self.mainView.viewCountDatailLabel.text = String(result.views.total.formatted())
             self.mainView.downloadDetailLabel.text = String(result.downloads.total.formatted())
             self.mainView.sizeDetailLabel.text = String(self.photoTopic.width.formatted()) + " x " + String(self.photoTopic.height.formatted())
-        } failHandler: {
+        } failHandler: { statusCode in
             print("호출 실패했습니다")
-        } statusHandler: { statusCode in
-            guard let message = APIStatus(statusCode: statusCode)?.alertMessage else { return }
-            self.alertMessage(code: statusCode, message: message)
+            self.alertMessage(code: statusCode.codeNumber, message: statusCode.alertMessage)
         }
 
     }

--- a/UnsplashImage/OurTopic/View/TopicPhotoViewController.swift
+++ b/UnsplashImage/OurTopic/View/TopicPhotoViewController.swift
@@ -90,18 +90,17 @@ final class TopicPhotoViewController: UIViewController {
                 print("switch-default")
                 break
             }
-            
+  
             self.group.leave()
             self.count -= 1
             print(self.count)
-        } failHandler: {
+        } failHandler: { statusCode in
             print("호출에 실패했습니다.")
+            self.alertMessage(code: statusCode.codeNumber, message: statusCode.alertMessage)
+            
             self.group.leave()
             self.count -= 1
             print("error", self.count)
-        } statusHandler: { statusCode in
-            guard let message = APIStatus(statusCode: statusCode)?.alertMessage else { return }
-            self.alertMessage(code: statusCode, message: message)
         }
 
     }

--- a/UnsplashImage/SearchPhoto/View/SearchPhotoDetailViewController.swift
+++ b/UnsplashImage/SearchPhoto/View/SearchPhotoDetailViewController.swift
@@ -64,11 +64,9 @@ final class SearchPhotoDetailViewController: UIViewController {
             self.mainView.viewCountDatailLabel.text = String(result.views.total.formatted())
             self.mainView.downloadDetailLabel.text = String(result.downloads.total.formatted())
             
-        } failHandler: {
+        } failHandler: { statusCode in
             print("호출 오류우우우우")
-        } statusHandler: { statusCode in
-            guard let message = APIStatus(statusCode: statusCode)?.alertMessage else { return }
-            self.alertMessage(code: statusCode, message: message)
+            self.alertMessage(code: statusCode.codeNumber, message: statusCode.alertMessage)
         }
 
     }

--- a/UnsplashImage/SearchPhoto/View/SearchPhotoViewController.swift
+++ b/UnsplashImage/SearchPhoto/View/SearchPhotoViewController.swift
@@ -101,12 +101,16 @@ final class SearchPhotoViewController: UIViewController, UISearchBarDelegate, UI
                     break
                 }
             }
-        } failHandler: {
+        } failHandler: { statusCode in
             print("호출 오류 발생 삐용")
-        } statusHandler: { statusCode in
-            guard let message = APIStatus(statusCode: statusCode)?.alertMessage else { return }
-            self.alertMessage(code: statusCode, message: message)
+            self.alertMessage(code: statusCode.codeNumber , message: statusCode.alertMessage)
         }
+        /*
+         statusHandler: { statusCode in
+             guard let message = APIStatus(statusCode: statusCode)?.alertMessage else { return }
+             self.alertMessage(code: statusCode, message: message)
+         }
+         */
     }
     
     @objc


### PR DESCRIPTION
## 한 일
1. 기존에는 successHandler, failHandler, statusHandler로 따로 관리했는데 연결 성공했을 때는 제외하고 failHandler로 상태코드 연결
2. @escaping 함수 전달 시, Int가 아닌 APIStatus 전달해 처리

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-23 at 13 56 56](https://github.com/user-attachments/assets/3b8b2b1b-3c59-4031-87e8-c34fecf97b02)
